### PR TITLE
Stop using outdated constant FILTER_FLAG_HOST_REQUIRED

### DIFF
--- a/modules/codebench/classes/Bench/ValidURL.php
+++ b/modules/codebench/classes/Bench/ValidURL.php
@@ -46,7 +46,7 @@ class Bench_ValidURL extends Codebench {
 
 	public function bench_filter_var($url)
 	{
-		return (bool) filter_var($url, FILTER_VALIDATE_URL, FILTER_FLAG_HOST_REQUIRED);
+		return (bool) filter_var($url, FILTER_VALIDATE_URL);
 	}
 
 	public function bench_regex($url)


### PR DESCRIPTION
Fix #69 